### PR TITLE
Updated link for Electron official documentation

### DIFF
--- a/docs/configuration/flags.md
+++ b/docs/configuration/flags.md
@@ -1,6 +1,6 @@
 # Flags
 
-The list of supported flags is available in the [Electron official documentation](https://electronjs.org/docs/api/chrome-command-line-switches#--ignore-connections-limitdomains)
+The list of supported flags is available in the [Electron official documentation](https://www.electronjs.org/docs/api/command-line-switches)
 
 All flags go under the switches key
 


### PR DESCRIPTION
Link to Electron official documentation about supported flags was redirecting to a 404 error page. New updated link added.